### PR TITLE
Add initial support for Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ## Overview
 This tool enables the user to:
 
-  1. Specify a ".txt" file to have it converted into an HTML webpage
-  2. Specify a folder containing multiple ".txt" files to convert all of them into HTML web pages. The program will recursively search subfolders for ".txt" files as well. 
+  1. Specify a ".txt" or ".md" file to have it converted into an HTML webpage
+  2. Specify a folder containing multiple ".txt" and ".md" files to convert all of them into HTML web pages. The program will recursively search subfolders for ".txt" files as well. 
 
 NOTE: This tool requires the use of a BASH shell.
 
@@ -52,7 +52,7 @@ This program is used to generate a static HTML web page from a given .txt file O
 The following options are available: 
     -v, --version: current program version
     -h, --help: program instructions
-    -i, --input: path input folder or file to be converted to HTML. Note that folders are recursively searched for .txt files.
+    -i, --input: path input folder or file to be converted to HTML. Note that folders are recursively searched for .txt and .md files.
     -s, --stylesheet: stylesheet url to be used in the HTML file
     
     The files will be saved in a '/dist' folder in the same directory as the input file/folder.
@@ -65,7 +65,7 @@ The following options are available:
 
 For a specific file, the user can run:
 
-`rohan-ssg -i PATH/TO/FILE/example.txt` or `rohan-ssg --input PATH/TO/FILE/example.txt`
+`rohan-ssg -i PATH/TO/FILE/example.txt` or `rohan-ssg --input PATH/TO/FILE/example.txt` or `rohan-ssg --input PATH/TO/FILE/example.md`
 
 This will then generate a `/dist` directory, containing the HTML file that had been generated.
 
@@ -73,7 +73,7 @@ For a folder:
 
 `rohan-ssg -i PATH/TO/FOLDER` or `rohan-ssg --input PATH/TO/FOLDER`
 
-Similar to above, this will also generate a `/dist` directory, which will contain all of the HTML files that had been generated from all of the .txt files inside of the specified folder (including subfolders). 
+Similar to above, this will also generate a `/dist` directory, which will contain all of the HTML files that had been generated from all of the .txt and .md files inside of the specified folder (including subfolders). 
 
 To specify a stylesheet to be applied to all HTML files, the user can choose to use the `-s` or `--stylesheet` option as follows:
 

--- a/helper.js
+++ b/helper.js
@@ -53,10 +53,8 @@ function generateSite(file, stylesheet = '') {
   //variable to hold whether the file is markdown
   let fileMarkdown = false;
 
-  // read each line of the text file
-  if (ext == '.txt')
-  {
-    rl.on('line', (line) => {
+  rl.on('line', (line) => {
+    if (ext == '.txt') {
       if (line.length === 0){
         emptyLines++;
       }
@@ -77,16 +75,13 @@ function generateSite(file, stylesheet = '') {
         else {
           text += (line + ' ');
         }
-      }
-    });
+    }
   }
-  else if (ext == '.md') {
-    fileMarkdown = true;
-    rl.on('line', (line) => {
+    else if (ext == '.md') {
       //check if the line is a heading 1
+      fileMarkdown = true;
       if (line.startsWith('# '))
       {
-        console.log("line: " + line);
         //cut the '# ' out of the line
         text = line.substring(2);
         body += `
@@ -95,13 +90,12 @@ function generateSite(file, stylesheet = '') {
       }
       else if (line != "")
       {
-        console.log("line2: " + line);
         body += `
         <p>${line}</p>
         `;
       }
-    })
-  }
+    }
+  });
   
   rl.on('close', () => {
     // generate HTML file

--- a/test/testMarkdown.md
+++ b/test/testMarkdown.md
@@ -1,0 +1,19 @@
+test text
+
+# hello
+
+test
+
+test
+
+test
+
+test
+
+# another heading
+
+sample text
+
+# final heading
+
+final text


### PR DESCRIPTION
This resolves issue rokaicker/StaticSiteGenerator#7. Users can now generate HTML files from Markdown files (.md).

This code adds to the generateSite() function in helper.js. It first checks whether the file is .txt or .md and will generate the HTML correctly based on the extension of the file. In addition, if the file is Markdown, it will check if the line is a Heading 1 and will convert Heading 1's into \<h1> tags in the HTML file. It checks for Heading 1's by checking if the line starts with "# ". I put this code in the same function because handling text and Markdown files is similar and I didn't want to clutter the code.

Also, I added a testing Markdown file called "testMarkdown.md" in the test folder.