### PR TITLE
Added italics and bold styling markdown syntax features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 ## Overview
 This tool enables the user to:
 
-  1. Specify a ".txt" or ".md" file to have it converted into an HTML webpage
+  1. Specify a ".txt" or ".md" file to have it converted into an HTML webpage.
   2. Specify a folder containing multiple ".txt" and ".md" files to convert all of them into HTML web pages. The program will recursively search subfolders for ".txt" files as well. 
+
+For markdown files, we currently support proper styling syntax features for italics, bold, heading 1, heading 2, and a link.
 
 NOTE: This tool requires the use of a BASH shell.
 

--- a/src/helper.js
+++ b/src/helper.js
@@ -53,8 +53,6 @@ function generateSite(file, stylesheet = '') {
   //variable to hold whether the file is markdown
   let fileMarkdown = false;
 
-  // regex to find markdown link 
-  const regex = /\[(.*?)\]\((.*?)\)/g;
 
   rl.on('line', (line) => {
     if (ext == '.txt') {
@@ -94,20 +92,24 @@ function generateSite(file, stylesheet = '') {
       else if (line.startsWith('## '))
       {
         //cut the '## ' out of the line
-	text = line.substring(3);
-	body += `
-	      <h2>${text}</h2>
-	`;
+        text = line.substring(3);
+        body += `
+        <h2>${text}</h2>
+        `;
       }
-      else if (regex.test(line))
-      {
-	//convert markdown link to href 
-	body += `
-	      <p>${line.replaceAll(regex, '<a href="$2">$1</a>')}</p>
-	`;
-      } 
       else if (line != "")
       {
+        //convert markdown link to href 
+        line = line.replace(/\[(.*?)\]\((.*?)\)/g, '<a href="$2">$1</a>');
+        //convert markdown bold ** to html <b> element
+        line = line.replace(/\*\*(.*)\*\*/g, '<b>$1</b>');
+        //convert markdown bold __ to html <b> element
+        line = line.replace(/__(.*)__/g, '<b>$1</b>');
+        //convert markdown italics * to html <i> element
+        line = line.replace(/\*(.*)\*/g, '<i>$1</i>');
+        //convert markdown italics _ to html <i> element
+        line = line.replace(/_(.*)_/g, '<i>$1</i>');
+        
         body += `
         <p>${line}</p>
         `;

--- a/test/test-folder/markdown.md
+++ b/test/test-folder/markdown.md
@@ -4,7 +4,6 @@ this is not a heading
 
 # this is another heading
 
-
 ## this is heading 2
 
 Above is to test heading 2 to see if markdown heading is converted into html link
@@ -12,3 +11,9 @@ Above is to test heading 2 to see if markdown heading is converted into html lin
 This line is to test markdown [link1](http://test.com/test).
 
 This is another test for markdown [link2](https:dev.to/my-blog). One more [link3](test@test.com) in the same line.
+
+This line is to test italics in different forms such as : *asterisk italics* and _underscore italics_.
+
+This line is to test bold in different forms such as : **asterisk bold** and __underscore bold__.
+
+This line is to test bold and italics combined : ***asterisk bold and italic*** and ___underscore bold and italic___.

--- a/test/testMarkdown.md
+++ b/test/testMarkdown.md
@@ -17,3 +17,9 @@ sample text
 # final heading
 
 final text
+
+This line is to test italics in different forms such as : *asterisk italics* and _underscore italics_.
+
+This line is to test bold in different forms such as : **asterisk bold** and __underscore bold__.
+
+This line is to test bold and italics combined : ***asterisk bold and italic*** and ___underscore bold and italic___.


### PR DESCRIPTION
Fixes #23 

My intention was to implement additional syntax features for the markdown files such as _italics_ and **bold**. They should be transformed into html properly and right now they are not. 

My solution is to replace all markdown styling symbols with the corresponding html elements. In markdown, `*sample text*` or `_sample text_` are used to display the sample text in italics and `**sample text**` or `__sample text__` are used to display the sample text in bold. Therefore, for html, they have to be transformed into `<i></i>` and `<b></b>` elements respectively. I integrated my code into the existing markdown module. I combined it with the links replacement part as it uses the same technique. 

I also added new lines to the testing markdown files to check my features.