### PR TITLE
Added New Feature: Support --config with Config File

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,37 @@
 # Static Site Generator - rohan-ssg.js
+
 ## Overview
+
 This tool enables the user to:
 
-  1. Specify a ".txt" or ".md" file to have it converted into an HTML webpage.
-  2. Specify a folder containing multiple ".txt" and ".md" files to convert all of them into HTML web pages. The program will recursively search subfolders for ".txt" files as well. 
+1. Specify a ".txt" or ".md" file to have it converted into an HTML webpage.
+2. Specify a folder containing multiple ".txt" and ".md" files to convert all of them into HTML web pages. The program will recursively search subfolders for ".txt" files as well.
 
 For markdown files, we currently support proper styling syntax features for italics, bold, heading 1, heading 2, and a link.
 
 NOTE: This tool requires the use of a BASH shell.
 
-
 ## Installation
-To install this program, first `git clone` the repository. 
+
+To install this program, first `git clone` the repository.
 
 Then open a terminal inside of the newly created folder, and run `npm install` to install the node dependencies.
 
-Then, in the same folder run `npm install -g` to globally install the command line tool. 
+Then, in the same folder run `npm install -g` to globally install the command line tool.
 
 This command will install the programming globally on your system.
 
-
 ## Options
 
-There are four options available to the user to use with this CLI program. 
+There are four options available to the user to use with this CLI program.
 
 | Short Form | Long Form    | Description                                                                                        |
-|------------|--------------|----------------------------------------------------------------------------------------------------|
+| ---------- | ------------ | -------------------------------------------------------------------------------------------------- |
 | -v         | --version    | Outputs the current version of the program.                                                        |
 | -h         | --help       | Outputs a help message explaining the program's usage.                                             |
 | -i         | --input      | Allows the user to specify either a single .txt file, or a folder containing .txt files.           |
 | -s         | --stylesheet | Allows the user to specify a URL containing a CSS stylesheet to apply to the generated HTML files. |
+| -c         | --config     | Allows the user to specify a URL containing a CSS stylesheet to apply to the generated HTML files. |
 
 ## Usage
 
@@ -44,23 +46,41 @@ Which will output:
 `The current version is: x.x.x`
 
 ### Help
+
 To see a message explaining the program, the user can run:
 
 `rohan-ssg -h` or `rohan-ssg --help`
 
 Which will output:
+
 ```
 This program is used to generate a static HTML web page from a given .txt file OR a folder containing .txt files.
-The following options are available: 
+The following options are available:
     -v, --version: current program version
     -h, --help: program instructions
     -i, --input: path input folder or file to be converted to HTML. Note that folders are recursively searched for .txt and .md files.
     -s, --stylesheet: stylesheet url to be used in the HTML file
-    
+
     The files will be saved in a '/dist' folder in the same directory as the input file/folder.
 
     For example, to generate a single HTML file from a .txt file with a specific stylesheet URL, use the following command:
     rohan-ssg -i .PATH/TO/FILE/input.txt -s https://example.com/stylesheet.css
+```
+
+### Config
+
+Should be a JSON file and can include **input, stylesheet, lang** options.
+
+The config file overrides other options on the command line and can miss some of the options available (defaults will be used in that case).
+
+Example:
+
+```
+{
+  "input": "test/test-folder",
+  "stylesheet": "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css",
+  "lang": "fr"
+}
 ```
 
 ### Input (with and without stylesheet)
@@ -75,14 +95,10 @@ For a folder:
 
 `rohan-ssg -i PATH/TO/FOLDER` or `rohan-ssg --input PATH/TO/FOLDER`
 
-Similar to above, this will also generate a `/dist` directory, which will contain all of the HTML files that had been generated from all of the .txt and .md files inside of the specified folder (including subfolders). 
+Similar to above, this will also generate a `/dist` directory, which will contain all of the HTML files that had been generated from all of the .txt and .md files inside of the specified folder (including subfolders).
 
 To specify a stylesheet to be applied to all HTML files, the user can choose to use the `-s` or `--stylesheet` option as follows:
 
 `rohan-ssg -i PATH/TO/FOLDER -s https://example.com/stylesheet.css` or `rohan-ssg -i PATH/TO/FILE/example.txt -s https://example.com/stylesheet.css`
 
-This will link the specified stylesheet (which must be a url) to all HTML files that have been generated. 
-
-
-
-
+This will link the specified stylesheet (which must be a url) to all HTML files that have been generated.

--- a/src/rohan-ssg.js
+++ b/src/rohan-ssg.js
@@ -21,6 +21,7 @@ program
   .option('-i, --input <input>', 'input folder or file')
   .option('-s, --stylesheet <stylesheet>', 'stylesheet url')
   .option('-l, --lang <lang>', 'language of the input file')
+  .option('-c, --config <config>', 'JSON config file')
 
 program.parse();
 
@@ -48,11 +49,37 @@ if (options.help){
     `);
 }
 
-const lang = options.lang || 'en-CA';
 
-if (options.input){
+var lang = options.lang || 'en-CA';
+var stylesheet = options.stylesheet;
+var input = options.input;
+
+if (options.config){
+  const path = options.config;
+  try {
+    // read local json file 
+    // https://heynode.com/tutorial/readwrite-json-files-nodejs/
+    const jsonString = fs.readFileSync(path);
+    const json = JSON.parse(jsonString);
+    if (json.lang != null) {
+      lang = json.lang;
+    }
+    if (json.stylesheet != null) {
+      stylesheet = json.stylesheet;
+    }
+    if (json.input != null) {
+      input = json.input;
+    }
+  } catch (err) {
+    console.log(err);
+    return;
+  }
+}
+
+
+if (input){
   // get path passed to program
-  const path = options.input;
+  const path = input;
   // check if path is a file or a folder
   // - based on https://stackoverflow.com/questions/15630770/node-js-check-if-path-is-file-or-directory
   fs.lstat(path, (err, stats) => {
@@ -63,8 +90,8 @@ if (options.input){
     // if the path points to a file
     if (stats.isFile()){
       // generate HTML file
-      if (options.stylesheet){
-        helper.generateSite(path, lang, options.stylesheet);
+      if (stylesheet){
+        helper.generateSite(path, lang, stylesheet);
       } else {
         helper.generateSite(path, lang);
       }
@@ -77,8 +104,8 @@ if (options.input){
       helper.recursiveFileSearch(path, fileArr);
       // generate HTML files for all .txt files in the directory
       fileArr.forEach((file) => {
-        if (options.stylesheet){
-          helper.generateSite(file, lang, options.stylesheet);
+        if (stylesheet){
+          helper.generateSite(file, lang, stylesheet);
         } else {
           helper.generateSite(file, lang);
         }

--- a/src/rohan-ssg.js
+++ b/src/rohan-ssg.js
@@ -41,6 +41,7 @@ if (options.help){
     -i, --input: path input folder or file to be converted to HTML. Note that folders are recursively searched for .txt files.
     -s, --stylesheet: stylesheet url to be used in the HTML file
     -l, --lang: language of the input file. If not specified, the language will be set to 'en-CA' by default.
+    -c, --config: JSON config file. If specified, it overrides other options on the command line.
     
     The files will be saved in a '/dist' folder in the same directory as the input file/folder.
 

--- a/test/ssg-config.json
+++ b/test/ssg-config.json
@@ -1,0 +1,3 @@
+{
+    "input": "test/test-folder"
+}


### PR DESCRIPTION
Fixes #29 

- [x] The -c or --config flags accept a file path to a JSON config file.
- [x]  If the file is missing, or can't be parsed as JSON, exit with an appropriate error message.
- [x]  If the -c or --config option is provided, ignore all other options (i.e., a config file overrides other options on the command line).
- [x]  The program should ignore any options in the config file it doesn't recognize. For example, if the SSG doesn't support stylesheets, ignore a stylesheet property.
- [x]  If the config file is missing any options, assume the usual defaults. For example, use dist/ as the output directory if it isn't specified.
- [x] Style of the original author is preserved 
- [x] README.md is adjusted accordingly